### PR TITLE
Fix support for mailto: and tel: links 

### DIFF
--- a/Sources/MarkdownView.Portable/MarkdownView.cs
+++ b/Sources/MarkdownView.Portable/MarkdownView.cs
@@ -1,4 +1,4 @@
-﻿namespace Xam.Forms.Markdown
+namespace Xam.Forms.Markdown
 {
     using System.Linq;
     using Markdig.Syntax;
@@ -426,7 +426,7 @@
 
                     var url = link.Url;
 
-                    if (!(url.StartsWith("http://") || url.StartsWith("https://")))
+                    if (!(url.StartsWith("http://") || url.StartsWith("https://") || url.StartsWith("mailto:")))
                     {
                         url = $"{this.RelativeUrlHost?.TrimEnd('/')}/{url.TrimStart('/')}";
                     }

--- a/Sources/MarkdownView.Portable/MarkdownView.cs
+++ b/Sources/MarkdownView.Portable/MarkdownView.cs
@@ -426,7 +426,7 @@ namespace Xam.Forms.Markdown
 
                     var url = link.Url;
 
-                    if (!(url.StartsWith("http://") || url.StartsWith("https://") || url.StartsWith("mailto:")))
+                    if (!(url.StartsWith("http://") || url.StartsWith("https://") || url.StartsWith("mailto:") || url.StartsWith("tel:")))
                     {
                         url = $"{this.RelativeUrlHost?.TrimEnd('/')}/{url.TrimStart('/')}";
                     }


### PR DESCRIPTION
Corrected an issue with mailto: and tel: links having / prepended to the URL causing Device.OpenUri to not open device mail or phone applications.  
Fixes #5 Hyperlink does not support mailto: and tel: links